### PR TITLE
When source and target and equal, only update the array once

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -99,8 +99,8 @@ ko.bindingHandlers.sortable = {
                     if (targetIndex >= 0) {
 						if (sourceParent === targetParent) {
 							var items = sourceParent();
+							ko.utils.arrayRemoveItem(items, item);
 							items.splice(targetIndex, 0, item);
-							items.remove(item);
 							targetParent(items);
 						} else {
 							sourceParent.remove(item);


### PR DESCRIPTION
When source and target observable arrays are the same, the plugin sends two updates: For removing the item from `sourceParent` and then for adding the item to `targetParent`.

This poorly formatted (sorry) commit handles this special case.

I was unable to find any tests that actually test the JQuery UI interaction, so I wasn't able to add a test for this, apologies.
