### PR TITLE
Adding 4th parameter to afterMove callback. 

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -82,6 +82,9 @@ ko.bindingHandlers.sortable = {
                 var sourceParent, targetParent, targetIndex, arg,
                     el = ui.item[0],
                     item = ko.utils.domData.get(el, itemKey);
+                    
+                //give access to parent node
+                var elParentNode = el.parentNode;
 
                 if (item) {
                     //identify parents
@@ -119,7 +122,7 @@ ko.bindingHandlers.sortable = {
 
                     //allow binding to accept a function to execute after moving the item
                     if (sortable.afterMove) {
-                       sortable.afterMove.call(this, arg, event, ui);
+                       sortable.afterMove.call(this, arg, event, ui, elParentNode);
                     }
                 }
             },


### PR DESCRIPTION
Use it in case when we have 1 sortable array and 2 buckets sharing it.

The simplest case is when "high priority" and "normal priority" buckets from your example http://jsfiddle.net/rniemeyer/Jr2rE/ share one array.
We need to know if item moved from one bucket to another, or it just changed place in the same bucket.

We can achieve it by calling " if (this !== elParentNode) " in afterMove callback.
