### PR TITLE
amd support

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -1,4 +1,13 @@
-(function(ko, $, undefined) {
+(function(factory) {
+    // Support three module loading scenarios
+    if (typeof define === 'function' && define['amd']) {
+        // AMD anonymous module
+        define(['knockout', 'jquery', 'jquery.ui.sortable'], factory);
+    } else {
+        // No module loader (plain <script> tag) - put directly in global namespace
+        factory(window['knockout'], jQuery);
+    }
+})(function(ko, $, undefined) {
     var ITEMKEY = "ko_sortItem",
         LISTKEY = "ko_sortList",
         PARENTKEY = "ko_parentList",
@@ -271,4 +280,4 @@
         }
     };
 
-})(ko, jQuery);
+});


### PR DESCRIPTION
Hello,

This PR adds amd support.  I didn't add draggable as dependencies as it appears to optional. You are free to add it. jquery-ui with amd support can be found [here](https://github.com/jrburke/jqueryui-amd)

P.S. Sorry, I've failed to install anvil.js, so you have to update build file yourself.

Thanks,
Alex
