### PR TITLE
Support for nested draggable/sortable pattern with isAccepted callback

### DIFF
--- a/build/knockout-sortable.js
+++ b/build/knockout-sortable.js
@@ -1,9 +1,9 @@
-//knockout-sortable 0.6.0 | (c) 2012 Ryan Niemeyer | http://www.opensource.org/licenses/mit-license
 (function(ko, $, undefined) {
     var ITEMKEY = "ko_sortItem",
         LISTKEY = "ko_sortList",
         PARENTKEY = "ko_parentList",
-        DRAGKEY = "ko_dragItem";
+        DRAGKEY = "ko_dragItem",
+        PARENTVMKEY = 'ko_parentvm';
 
     //internal afterRender that adds meta-data to children
     var addMetaDataAfterRender = function(elements, data) {
@@ -98,7 +98,7 @@
 
             //initialize sortable binding after template binding has rendered in update function
             setTimeout(function() {
-                var dragItem;
+                var dragItem, currentParentViewModel;
                 $element.sortable(ko.utils.extend(sortable.options, {
                     start: function(event, ui) {
                         //make sure that fields have a chance to update model
@@ -109,22 +109,53 @@
                     },
                     receive: function(event, ui) {
                         dragItem = ko.utils.domData.get(ui.item[0], DRAGKEY);
-                        if (dragItem && dragItem.clone) {
-                            dragItem = dragItem.clone();
+                    },
+                    sort: function (event, ui) {
+                        // If no isAccepted callback, return
+                        if (!sortable.isAccepted) return;
+                        // Get placeholder and parent DOM elements and make sure they're set
+                        var helper = ui.helper,
+                            placeholderParent = ui.placeholder && ui.placeholder.size() ? ui.placeholder.parent() : null;
+                        if (!placeholderParent.size() || !helper.size()) return;
+                        // Get parent viewmodel and item viewmodel attached and make sure they're set
+                        var parentViewModel = ko.utils.domData.get(placeholderParent[0], PARENTVMKEY),
+                            itemViewModel = ko.utils.domData.get(helper[0], ITEMKEY) || ko.utils.domData.get(helper[0], DRAGKEY);
+                        if (!parentViewModel || !itemViewModel) return;
+                        // If changing the parent that we're dragging over, call isValid to see if it's a valid target
+                        if (!currentParentViewModel || currentParentViewModel !== parentViewModel) {
+                            // Set current parent so we only call isValid once per parent change
+                            currentParentViewModel = parentViewModel;
+                            var isValid = sortable.isAccepted.call(currentParentViewModel, currentParentViewModel, itemViewModel);
+                            // Set placeholder valid/invalid state
+                            var body = $('body');
+                            if (!isValid) {
+                                ui.placeholder.addClass(sortable.invalidDropClass);
+                                body.css('cursor', sortable.invalidDropCursor);
+                            }
+                            else {
+                                ui.placeholder.removeClass(sortable.invalidDropClass);
+                                body.css('cursor', sortable.options.cursor || 'auto');
+                            }
                         }
                     },
                     update: function(event, ui) {
-                        var sourceParent, targetParent, targetIndex, i, targetUnwrapped, arg,
+                        var sourceParent, targetParent, targetParentVm, targetIndex, i, targetUnwrapped, arg,
                             el = ui.item[0],
+                            isDrag = !!dragItem,
                             item = ko.utils.domData.get(el, ITEMKEY) || dragItem;
 
                         dragItem = null;
+                        currentParentViewModel = null;
 
                         if (item) {
                             //identify parents
                             sourceParent = ko.utils.domData.get(el, PARENTKEY);
                             targetParent = ko.utils.domData.get(el.parentNode, LISTKEY);
+                            targetParentVm = ko.utils.domData.get(el.parentNode, PARENTVMKEY);
                             targetIndex = ko.utils.arrayIndexOf(ui.item.parent().children(), el);
+                            if (isDrag && item.clone) {
+                                item = item.clone.call(item, targetParentVm);
+                            }
 
                             //take destroyed items into consideration
                             if (!templateOptions.includeDestroyed) {
@@ -137,7 +168,7 @@
                                 }
                             }
 
-                            if (sortable.beforeMove || sortable.afterMove) {
+                            if (sortable.beforeMove || sortable.afterMove || sortable.isAccepted) {
                                 arg = {
                                     item: item,
                                     sourceParent: sourceParent,
@@ -152,6 +183,20 @@
                             if (sortable.beforeMove) {
                                 sortable.beforeMove.call(this, arg, event, ui);
                                 if (arg.cancelDrop) {
+                                    //call cancel on the correct list
+                                    if (arg.sourceParent) {
+                                        $(arg.sourceParent === arg.targetParent ? this : ui.sender).sortable('cancel');
+                                    }
+                                    //for a draggable item just remove the element
+                                    else {
+                                        $(el).remove();
+                                    }
+                                    return;
+                                }
+                            }
+                            if (sortable.isAccepted) {
+                                var isValid = sortable.isAccepted.call(targetParentVm, targetParentVm, item);
+                                if (isValid === false) {
                                     //call cancel on the correct list
                                     if (arg.sourceParent) {
                                         $(arg.sourceParent === arg.targetParent ? this : ui.sender).sortable('cancel');
@@ -186,6 +231,10 @@
                         if (updateActual) {
                             updateActual.apply(this, arguments);
                         }
+                        // Clear DOM data on helper
+                        if (ui.helper && ui.helper.size()) {
+                            ko.utils.domData.clear(ui.helper[0]);
+                        }
                     },
                     connectWith: sortable.connectClass ? "." + sortable.connectClass : false
                 }));
@@ -213,6 +262,7 @@
 
             //attach meta-data
             ko.utils.domData.set(element, LISTKEY, templateOptions.foreach);
+            ko.utils.domData.set(element, PARENTVMKEY, data);
 
             //call template binding's update with correct options
             ko.bindingHandlers.template.update(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
@@ -221,6 +271,8 @@
         allowDrop: true,
         afterMove: null,
         beforeMove: null,
+        invalidDropClass: 'invalid-drop',
+        invalidDropCursor: 'not-allowed',
         options: {}
     };
 
@@ -232,7 +284,8 @@
                 draggableOptions = ko.utils.extend({}, ko.bindingHandlers.draggable.options),
                 templateOptions = prepareTemplateOptions(valueAccessor, "data"),
                 connectClass = value.connectClass || ko.bindingHandlers.draggable.connectClass,
-                isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.draggable.isEnabled;
+                isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.draggable.isEnabled,
+                startActual = draggableOptions.start;
 
             value = value.data || value;
 
@@ -245,6 +298,14 @@
             //setup connection to a sortable
 
             draggableOptions.connectToSortable = connectClass ? "." + connectClass : false;
+            draggableOptions.start = function (event, ui) {
+                var helper = ui.helper;
+                if (!helper || !helper.size()) return;
+                ko.utils.domData.set(helper[0], DRAGKEY, value);
+                if (startActual) {
+                    startActual.apply(this, arguments);
+                }
+            };
 
             //initialize draggable
             $(element).draggable(draggableOptions);

--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -2,7 +2,8 @@
     var ITEMKEY = "ko_sortItem",
         LISTKEY = "ko_sortList",
         PARENTKEY = "ko_parentList",
-        DRAGKEY = "ko_dragItem";
+        DRAGKEY = "ko_dragItem",
+        PARENTVMKEY = 'ko_parentvm';
 
     //internal afterRender that adds meta-data to children
     var addMetaDataAfterRender = function(elements, data) {
@@ -97,7 +98,7 @@
 
             //initialize sortable binding after template binding has rendered in update function
             setTimeout(function() {
-                var dragItem;
+                var dragItem, currentParentViewModel;
                 $element.sortable(ko.utils.extend(sortable.options, {
                     start: function(event, ui) {
                         //make sure that fields have a chance to update model
@@ -108,22 +109,53 @@
                     },
                     receive: function(event, ui) {
                         dragItem = ko.utils.domData.get(ui.item[0], DRAGKEY);
-                        if (dragItem && dragItem.clone) {
-                            dragItem = dragItem.clone();
+                    },
+                    sort: function (event, ui) {
+                        // If no isAccepted callback, return
+                        if (!sortable.isAccepted) return;
+                        // Get placeholder and parent DOM elements and make sure they're set
+                        var helper = ui.helper,
+                            placeholderParent = ui.placeholder && ui.placeholder.size() ? ui.placeholder.parent() : null;
+                        if (!placeholderParent.size() || !helper.size()) return;
+                        // Get parent viewmodel and item viewmodel attached and make sure they're set
+                        var parentViewModel = ko.utils.domData.get(placeholderParent[0], PARENTVMKEY),
+                            itemViewModel = ko.utils.domData.get(helper[0], ITEMKEY) || ko.utils.domData.get(helper[0], DRAGKEY);
+                        if (!parentViewModel || !itemViewModel) return;
+                        // If changing the parent that we're dragging over, call isValid to see if it's a valid target
+                        if (!currentParentViewModel || currentParentViewModel !== parentViewModel) {
+                            // Set current parent so we only call isValid once per parent change
+                            currentParentViewModel = parentViewModel;
+                            var isValid = sortable.isAccepted.call(currentParentViewModel, currentParentViewModel, itemViewModel);
+                            // Set placeholder valid/invalid state
+                            var body = $('body');
+                            if (!isValid) {
+                                ui.placeholder.addClass(sortable.invalidDropClass);
+                                body.css('cursor', sortable.invalidDropCursor);
+                            }
+                            else {
+                                ui.placeholder.removeClass(sortable.invalidDropClass);
+                                body.css('cursor', sortable.options.cursor || 'auto');
+                            }
                         }
                     },
                     update: function(event, ui) {
-                        var sourceParent, targetParent, targetIndex, i, targetUnwrapped, arg,
+                        var sourceParent, targetParent, targetParentVm, targetIndex, i, targetUnwrapped, arg,
                             el = ui.item[0],
+                            isDrag = !!dragItem,
                             item = ko.utils.domData.get(el, ITEMKEY) || dragItem;
 
                         dragItem = null;
+                        currentParentViewModel = null;
 
                         if (item) {
                             //identify parents
                             sourceParent = ko.utils.domData.get(el, PARENTKEY);
                             targetParent = ko.utils.domData.get(el.parentNode, LISTKEY);
+                            targetParentVm = ko.utils.domData.get(el.parentNode, PARENTVMKEY);
                             targetIndex = ko.utils.arrayIndexOf(ui.item.parent().children(), el);
+                            if (isDrag && item.clone) {
+                                item = item.clone.call(item, targetParentVm);
+                            }
 
                             //take destroyed items into consideration
                             if (!templateOptions.includeDestroyed) {
@@ -136,7 +168,7 @@
                                 }
                             }
 
-                            if (sortable.beforeMove || sortable.afterMove) {
+                            if (sortable.beforeMove || sortable.afterMove || sortable.isAccepted) {
                                 arg = {
                                     item: item,
                                     sourceParent: sourceParent,
@@ -151,6 +183,20 @@
                             if (sortable.beforeMove) {
                                 sortable.beforeMove.call(this, arg, event, ui);
                                 if (arg.cancelDrop) {
+                                    //call cancel on the correct list
+                                    if (arg.sourceParent) {
+                                        $(arg.sourceParent === arg.targetParent ? this : ui.sender).sortable('cancel');
+                                    }
+                                    //for a draggable item just remove the element
+                                    else {
+                                        $(el).remove();
+                                    }
+                                    return;
+                                }
+                            }
+                            if (sortable.isAccepted) {
+                                var isValid = sortable.isAccepted.call(targetParentVm, targetParentVm, item);
+                                if (isValid === false) {
                                     //call cancel on the correct list
                                     if (arg.sourceParent) {
                                         $(arg.sourceParent === arg.targetParent ? this : ui.sender).sortable('cancel');
@@ -185,6 +231,10 @@
                         if (updateActual) {
                             updateActual.apply(this, arguments);
                         }
+                        // Clear DOM data on helper
+                        if (ui.helper && ui.helper.size()) {
+                            ko.utils.domData.clear(ui.helper[0]);
+                        }
                     },
                     connectWith: sortable.connectClass ? "." + sortable.connectClass : false
                 }));
@@ -212,6 +262,7 @@
 
             //attach meta-data
             ko.utils.domData.set(element, LISTKEY, templateOptions.foreach);
+            ko.utils.domData.set(element, PARENTVMKEY, data);
 
             //call template binding's update with correct options
             ko.bindingHandlers.template.update(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
@@ -220,6 +271,8 @@
         allowDrop: true,
         afterMove: null,
         beforeMove: null,
+        invalidDropClass: 'invalid-drop',
+        invalidDropCursor: 'not-allowed',
         options: {}
     };
 
@@ -231,7 +284,8 @@
                 draggableOptions = ko.utils.extend({}, ko.bindingHandlers.draggable.options),
                 templateOptions = prepareTemplateOptions(valueAccessor, "data"),
                 connectClass = value.connectClass || ko.bindingHandlers.draggable.connectClass,
-                isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.draggable.isEnabled;
+                isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.draggable.isEnabled,
+                startActual = draggableOptions.start;
 
             value = value.data || value;
 
@@ -244,6 +298,14 @@
             //setup connection to a sortable
 
             draggableOptions.connectToSortable = connectClass ? "." + connectClass : false;
+            draggableOptions.start = function (event, ui) {
+                var helper = ui.helper;
+                if (!helper || !helper.size()) return;
+                ko.utils.domData.set(helper[0], DRAGKEY, value);
+                if (startActual) {
+                    startActual.apply(this, arguments);
+                }
+            };
 
             //initialize draggable
             $(element).draggable(draggableOptions);


### PR DESCRIPTION
Ryan, I've been using your knockout-sortable plugin in a large project that I'm working on and I found the need to add some supporting code for a nested draggable/sortable pattern where each view model can determine whether it accepts the dragged item or not. I've implemented this and also created an associated jsfiddle with the pattern of the intended use. The overall changes are around making the clone callback take the view model that you are adding to as a parameter and adding an isAccepted callback that works similarly (delegates the responsibility of whether the target accepts the element to the view model of the target). Take a look if you get a chance: http://jsfiddle.net/dflor003/hBv4p/
