### PR TITLE
Make sortable and deferred cooperate

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -167,6 +167,9 @@
                             if (targetIndex >= 0) {
                                 if (sourceParent) {
                                     sourceParent.remove(item);
+                                    if (ko.processAllDeferredBindingUpdates) {
+                                        ko.processAllDeferredBindingUpdates();
+                                    }
                                 }
 
                                 targetParent.splice(targetIndex, 0, item);
@@ -175,6 +178,9 @@
                             //rendering is handled by manipulating the observableArray; ignore dropped element
                             ko.utils.domData.set(el, ITEMKEY, null);
                             ui.item.remove();
+                            if (ko.processAllDeferredBindingUpdates) {
+                                ko.processAllDeferredBindingUpdates();
+                            }
 
                             //allow binding to accept a function to execute after moving the item
                             if (sortable.afterMove) {


### PR DESCRIPTION
While this was officially tabled a while ago (rniemeyer/knockout-sortable#9), it would be good to at least have these two play nice with each other out of the box, until a better fix can be worked in.
