### PR TITLE
Fixe for "cannot call methods on sortable prior to initialization"

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -104,7 +104,7 @@
             updateActual = sortable.options.update;
 
             //initialize sortable binding after template binding has rendered in update function
-            setTimeout(function() {
+            var createTimeout = setTimeout(function() {
                 var dragItem;
                 $element.sortable(ko.utils.extend(sortable.options, {
                     start: function(event, ui) {
@@ -220,7 +220,8 @@
 
             //handle disposal
             ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
-                $element.sortable("destroy");
+                $element.data().sortable && $element.sortable("destroy"); // only call destroy if sortable has been created
+                clearTimeout(createTimeout); // do not create the sortable if the element has been removed from dom
             });
 
             return { 'controlsDescendantBindings': true };


### PR DESCRIPTION
If the binded element is removed before initialization, the "cannot call methods on sortable prior to initialization" error occur.
This fix checks for the sortable data is stored on the element, and only call "destroy" if the data is present. 
Also, it clears the timeout, preventing the sortable to be created on an element just removed.
