### PR TITLE
Added Droppable

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -358,7 +358,7 @@
     					}
 
 						//is the target an observableArray
-    					if (typeof targetParent.length == "number") {
+    					if (ko.isObservable(targetParent) && targetParent.splice != undefined) {
     						if (targetIndex && targetIndex >= 0)
     							targetParent.splice(targetIndex, 0, item);
     						else

--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -314,7 +314,7 @@
     			drop: function (event, ui) {
     				var sourceParent, targetParent, targetIndex, i, targetUnwrapped, arg,
 						   el = ui.draggable[0],
-						   item = ko.utils.domData.get(el, ITEMKEY);
+						   item = ko.utils.domData.get(el, ITEMKEY) || ko.utils.domData.get(el, DRAGKEY);
 
     				if (item && item.clone)
     					item = item.clone();

--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -297,15 +297,15 @@
                 dropActual;
 
     		$.extend(true, droppable, ko.bindingHandlers.droppable);
-    		if (typeof value.length == "number") {
-    			droppable.data = value;
-    		} else {
+    		if (value.data) {
     			if (value.options && droppable.options) {
     				ko.utils.extend(droppable.options, value.options);
     				delete value.options;
     			}
     			ko.utils.extend(droppable, value);
-    		}
+    		} else {
+    			droppable.data = value;
+    		}   
     			   		
 
     		dropActual = droppable.options.drop;
@@ -322,7 +322,7 @@
     				if (item) {
     					sourceParent = ko.utils.domData.get(el, PARENTKEY);
     					targetParent = droppable.data
-    					targetIndex = 0;
+    					targetIndex;
 
     					if (droppable.beforeMove || droppable.afterMove) {
     						arg = {
@@ -342,11 +342,7 @@
     							//call cancel on the correct list
     							if (arg.sourceParent) {
     								$(arg.sourceParentNode).sortable('cancel');
-    							} //for a droppable item just remove the element
-    							else {
-    								$(el).remove();
     							}
-
     							return;
     						}
     						targetIndex = arg.targetIndex;
@@ -361,10 +357,13 @@
     						}
     					}
 
-    					if (targetIndex && targetIndex >= 0)
-    						targetParent.splice(targetIndex, 0, item);
-    					else
-    						targetParent.push(item);
+						//is the target an observableArray
+    					if (typeof targetParent.length == "number") {
+    						if (targetIndex && targetIndex >= 0)
+    							targetParent.splice(targetIndex, 0, item);
+    						else
+    							targetParent.push(item);
+    					}
 
     					//rendering is handled by manipulating the observableArray; ignore dropped element
     					ko.utils.domData.set(el, ITEMKEY, null);
@@ -384,8 +383,7 @@
     						dropActual.apply(this, arguments);
     					}
     				}
-    			},
-    			accept: droppable.options.accept ? droppable.options.accept : (droppable.connectClass ? "." + droppable.connectClass : "*")
+    			}
     		}));
 
     		//handle enabling/disabling
@@ -402,7 +400,6 @@
     	update: function (element, valueAccessor, allBindingsAccessor, data, context) {
 
     	},
-    	connectClass: 'ko_container',
     	targetIndex: null,
     	afterMove: null,
     	beforeMove: null,

--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -321,8 +321,7 @@
 
     				if (item) {
     					sourceParent = ko.utils.domData.get(el, PARENTKEY);
-    					targetParent = droppable.data
-    					targetIndex;
+    					targetParent = droppable.data;
 
     					if (droppable.beforeMove || droppable.afterMove) {
     						arg = {


### PR DESCRIPTION
I needed a droppable target that would add items to an observable array without a sortable. Using the seating chart sample, it would allow you to drop students on table names with out having any template/child elements.

connectClass, beforeMove and afterMove, options, isEnabled all work the same (connectClass set's the droppable's accept)

An additional property, targetIndex, specifies where to put the new item, by default (null) it is appended. You can safely set to 0 to put at the start, or set it in beforeMove.

Every once in a while, I see a "Cannot call method 'removeChild' of null " on the source placeholder. Not sure what that is about, timing maybe. Appears to be this issue with JQuery UI: http://bugs.jqueryui.com/ticket/6054 

Brian
