### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 **Additional Options**
 
-* **connectClass** - specify the class that should be used to indicate a droppable target.  The default class is "ko_container".  This value can be passed in the binding or configured globally by setting `ko.bindingHandlers.sortable.connectClass`.
+* **connectClass** - specify the class that should be used to indicate a droppable target.  The default class is "ko_container".  This value can be passed in the binding or configured globally by setting `ko.bindingHandlers.sortable.connectClass`.  Setting this to false in the binding will limit sortable items to their current container, which is useful when the sortable binding is nested in a foreach binding.
 
 * **allowDrop** - specify whether this container should be a target for drops.  This can be a static value, observable, or a function that is passed the observableArray as its first argument.  If a function is specified, then it will be executed in a computed observable, so it will run again whenever any dependencies are updated.  This option can be passed in the binding or configured globally by setting `ko.bindingHandlers.sortable.allowDrop`.
 


### PR DESCRIPTION
looking at the code it looks like the false value is intended to work this way, but doesn't seem to be documented.  I found out about it from http://stackoverflow.com/questions/12408015/prevent-items-to-be-droppable-in-other-parent-child-elements.  If this isn't intended behaviour, but just a side effect, then please dismiss this and indicate the "right" way to limit draggables to their existing container.
