### PR TITLE
Added helper function to fix table widths when dragging

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -104,6 +104,14 @@
             startActual = sortable.options.start;
             updateActual = sortable.options.update;
 
+            // add helper object to keep widths correct when dragging table rows
+            sortable.options.helper = function(e, ui) {
+                ui.children().each(function() {
+                    $(this).width($(this).width());
+                });
+                return ui;
+            };
+
             //initialize sortable binding after template binding has rendered in update function
             var createTimeout = setTimeout(function() {
                 var dragItem;


### PR DESCRIPTION
When dragging table rows the widths of the cells compress to content and loose their set values.  I have added a helper function to the sortable options to fix the widths.

``` javascript
sortable.options.helper = function(e, ui) {
  ui.children().each(function() {
     $(this).width($(this).width());
  });
  return ui;
};
```
