### PR TITLE
Decreased amount of updates

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -315,27 +315,34 @@
     };
 
     function updateItemLocation(params) {
-        var sourceParentValue = ko.unwrap(params.sourceParent);
-        var targetParentValue = ko.unwrap(params.targetParent);
+        var sourceParentValue = unwrap(params.sourceParent);
+        var targetParentValue = unwrap(params.targetParent);
         if (sourceParentValue) {
-            params.sourceParent.valueWillMutate();
+            tryToCall(params.sourceParent, 'valueWillMutate');
             sourceParentValue.splice(params.sourceIndex, 1);
         }
 
         if (sourceParentValue !== targetParentValue) {
-            params.targetParent.valueWillMutate();
+            tryToCall(params.targetParent, 'valueWillMutate');
         }
         targetParentValue.splice(params.targetIndex, 0, params.item);
 
         if (targetParentValue === sourceParentValue) {
-            params.sourceParent.valueHasMutated();
+            tryToCall(params.sourceParent, 'valueHasMutated');
             //if using deferred updates plugin, force updates
             if (ko.processAllDeferredBindingUpdates) {
                 ko.processAllDeferredBindingUpdates();
             }
         } else {
-            sourceParentValue && params.sourceParent.valueHasMutated();
-            params.targetParent.valueHasMutated();
+            sourceParentValue && tryToCall(params.sourceParent, 'valueHasMutated');
+            tryToCall(params.targetParent, 'valueHasMutated');
         }
+    }
+
+    function tryToCall(object, method) {
+        if (typeof object[method] === 'function') {
+            return object[method]();
+        }
+        return null;
     }
 });


### PR DESCRIPTION
I rewrote a part of the code which is responsible for updating item position. So, now if you move items inside one array `foreach` binding receives only one update from the observable array. In this case when `foreach` calls `ko.utils.compareArrays` it receives comparing results where remove/added item has move index and re-rendering will not happen. DOM manipulations (moving items) can be under responsibility of jquery sortable plugin. You can check this plunker: http://plnkr.co/edit/P7F12EDG9v5iWHN5JvEA?p=preview . Open console and you will see that `new item created` will be only shown in 2 cases:
1. initial rendering
2. if added new item from another source

And another plunker for draggable: http://plnkr.co/edit/P7F12EDG9v5iWHN5JvEA
