### PR TITLE
move DOM nodes instead of removing and adding them again when moving an item within it's current list

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -226,13 +226,9 @@
                                         // notify 'beforeChange' subscribers
                                         sourceParent.valueWillMutate();
 
+										// move from source index ...
                                         underlyingList.splice(sourceIndex, 1);
-
-                                        //if using deferred updates plugin, force updates
-                                        if (ko.processAllDeferredBindingUpdates) {
-                                            ko.processAllDeferredBindingUpdates();
-                                        }
-
+										// ... to target index
                                         underlyingList.splice(targetIndex, 0, item);
 
                                         // notify subscribers

--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -203,20 +203,51 @@
 
                             if (targetIndex >= 0) {
                                 if (sourceParent) {
-                                    sourceParent.splice(sourceIndex, 1);
+                                    if (sourceParent !== targetParent) {
+                                        // moving from one list to another
 
-                                    //if using deferred updates plugin, force updates
-                                    if (ko.processAllDeferredBindingUpdates) {
-                                        ko.processAllDeferredBindingUpdates();
+                                        sourceParent.splice(sourceIndex, 1);
+
+                                        //if using deferred updates plugin, force updates
+                                        if (ko.processAllDeferredBindingUpdates) {
+                                            ko.processAllDeferredBindingUpdates();
+                                        }
+
+                                        targetParent.splice(targetIndex, 0, item);
+
+                                        //rendering is handled by manipulating the observableArray; ignore dropped element
+                                        dataSet(el, ITEMKEY, null);
+                                        ui.item.remove();
+                                    }
+                                    else {
+                                        // moving within same list
+                                        var underlyingList = unwrap(sourceParent);
+
+                                        // notify 'beforeChange' subscribers
+                                        sourceParent.valueWillMutate();
+
+                                        underlyingList.splice(sourceIndex, 1);
+
+                                        //if using deferred updates plugin, force updates
+                                        if (ko.processAllDeferredBindingUpdates) {
+                                            ko.processAllDeferredBindingUpdates();
+                                        }
+
+                                        underlyingList.splice(targetIndex, 0, item);
+
+                                        // notify subscribers
+                                        sourceParent.valueHasMutated();
                                     }
                                 }
+                                else {
+                                    // drop new element from outside
+                                    targetParent.splice(targetIndex, 0, item);
 
-                                targetParent.splice(targetIndex, 0, item);
+                                    //rendering is handled by manipulating the observableArray; ignore dropped element
+                                    dataSet(el, ITEMKEY, null);
+                                    ui.item.remove();
+                                }
                             }
-
-                            //rendering is handled by manipulating the observableArray; ignore dropped element
-                            dataSet(el, ITEMKEY, null);
-                            ui.item.remove();
 
                             //if using deferred updates plugin, force updates
                             if (ko.processAllDeferredBindingUpdates) {


### PR DESCRIPTION
First of all thank you for this great knockout binding, it saved me huge amount of time!

Currently DOM nodes are removed and a new DOM node is added, when an item is moved from its position to another position. This caused some trouble because i was doing some fancy layout stuff with the DOM nodes in the sortable list and whenever i moved an item in the list the DOM nodes got recreated and all the fancy stuff i did to them had to be done again. This caused some small performance issues and some severe layout issues due to transitions running again after moving an element and so on.

However i solved it by checking if an item is moved within it's current list. In that case the item is really moved instead of removing and adding it at another position.

Maybe this helps someone who has a similar problem.

Keep on the good work!

best regards,
Crunc
