### PR TITLE
Prevent to be invoked afterAdd when sorted an item.

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -14,7 +14,7 @@
         DRAGKEY = "ko_dragItem",
         unwrap = ko.utils.unwrapObservable,
         dataGet = ko.utils.domData.get,
-        dataSet = ko.utils.domData.set;
+        dataSet = ko.utils.domData.set,
         preventAfterAdd = [];
 
     //internal afterRender that adds meta-data to children


### PR DESCRIPTION
afterAdd callback has been invoked at "after add an item" and "after sort an item".
I don't hope that afterAdd be invoked when an item sorted.

``` javascript
function onAfterAdd(element) {
   // If merge this request,
   // this function will be invoked only after added a new item
}
```

``` html
<ul data-bind="sortable: { data: items, afterAdd: onAfterAdd }">
    <li data-bind="text: $data"></li>
</ul>
```
