### PR TITLE
Set templateEngine on template options

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -44,6 +44,9 @@
             result[option] = options[option] || ko.bindingHandlers.sortable[option];
         });
 
+		// apply an instance of the TemplateEngine to the options so it won't fail to render in knockout executeTemplate()
+		result.templateEngine = ko.nativeTemplateEngine.instance;
+
         //use an afterRender function to add meta-data
         if (dataName === "foreach") {
             if (result.afterRender) {


### PR DESCRIPTION
Apply an instance of the TemplateEngine to the options so it won't fail
to render in knockout executeTemplate(). Right now it won’t render
anything because TemplateEngine is undefined. 
I'm not sure why this works, but it does for me.
