### PR TITLE
Allow draggable data to be a falsy value

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -308,7 +308,7 @@
                 connectClass = value.connectClass || ko.bindingHandlers.draggable.connectClass,
                 isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.draggable.isEnabled;
 
-            value = value.data || value;
+            value = "data" in value ? value.data : value;
 
             //set meta-data
             dataSet(element, DRAGKEY, value);


### PR DESCRIPTION
When the draggable data is falsy, it gets replaced by the value of the binding. This caused an issue for me when I was using $index() as the data, since 0 is falsy.
