### PR TITLE
Add support for CommonJS module loaders

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -2,6 +2,12 @@
     if (typeof define === "function" && define.amd) {
         // AMD anonymous module
         define(["knockout", "jquery", "jquery.ui.sortable"], factory);
+    } else if (typeof module === "object") {
+        // CommonJS module
+        var ko = require("knockout");
+        var jQuery = require("jquery");
+        require("jquery.ui.sortable");
+        factory(ko, jQuery);
     } else {
         // No module loader (plain <script> tag) - put directly in global namespace
         factory(window.ko, jQuery);


### PR DESCRIPTION
Allows knockout-sortable to be loaded with CommonJS-compliant loaders, e.g. Browserify and Webpack.
