### PR TITLE
Fixed wrong CommonJS jQuery UI dependency

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -6,7 +6,7 @@
         // CommonJS module
         var ko = require("knockout"),
             jQuery = require("jquery");
-        require("jquery.ui/sortable");
+        require("jquery-ui/sortable");
         factory(ko, jQuery);
     } else {
         // No module loader (plain <script> tag) - put directly in global namespace


### PR DESCRIPTION
Right `npm` package name is `jquery-ui`, not `jquery.ui`.

https://www.npmjs.com/package/jquery-ui