### PR TITLE
Knockout 3.4 deferUpdates

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -258,6 +258,11 @@
                                         if (ko.processAllDeferredBindingUpdates) {
                                             ko.processAllDeferredBindingUpdates();
                                         }
+                                        
+                                        //if using deferred updates on knockout 3.4, force updates
+                                        if(ko.options.deferUpdates) {
+                                            ko.tasks.runEarly();
+                                        }
                                     }
 
                                     targetParent.splice(targetIndex, 0, item);
@@ -277,6 +282,11 @@
                                             //if using deferred updates plugin, force updates
                                             if (ko.processAllDeferredBindingUpdates) {
                                                 ko.processAllDeferredBindingUpdates();
+                                            }
+                                            
+                                            //if using deferred updates on knockout 3.4, force updates
+                                            if(ko.options.deferUpdates) {
+                                                ko.tasks.runEarly();
                                             }
 
                                             targetParent.splice(targetIndex, 0, item);


### PR DESCRIPTION
Hi @rniemeyer ,

I've run into some issues when using deferUpdates on ko 3.4 with knockout-sortable. The `afterMove` function is called only once for each element: [sample fiddle](https://jsfiddle.net/ngj35L1s/)

Apparently, setting the `strategyMove` to true seems to fix the problem: [sample fiddle](https://jsfiddle.net/dm2h0br0/1/)

I realized that you are [handling deferred updates](https://github.com/rniemeyer/knockout-sortable/blob/master/src/knockout-sortable.js#L257) for the @mbest plugin 

My understanding is that we also need to do it for the deferred updates implementation on ko 3.4. Does it make sense?

This seems to fix the problem both for the [strategyMove=true](https://jsfiddle.net/dm2h0br0/2/) and [strategyMove=false](https://jsfiddle.net/dm2h0br0/4/)

 