### PR TITLE
Droppable binding: support additional parameters

### DIFF
--- a/spec/knockout-sortable.spec.js
+++ b/spec/knockout-sortable.spec.js
@@ -1154,7 +1154,7 @@ describe("knockout-sortable", function(){
                 options = {
                     elems: $("<div data-bind='droppable: dropTo'></div>"),
                     vm: {
-                        dropTo: function(item) {
+                        dropTo: function(item, event, ui) {
                             result = item;
                         }
                      }
@@ -1166,6 +1166,34 @@ describe("knockout-sortable", function(){
                 expect(options.root.droppable("instance")).toBeTruthy();
             });
         });
+
+        describe("when dropping to a function with multiple parameters", function() {
+            var result, resultEvent, resultUi;
+            beforeEach(function() {
+                result = null;
+                resultEvent = null;
+                resultUi = null;
+
+                options = {
+                    elems: $("<div data-bind='droppable: dropTo'></div>"),
+                    vm: {
+                        dropTo: function(item, event, ui) {
+                            result = item;
+                            resultEvent = event;
+                            resultUi = ui;
+                        }
+                    }
+                };
+
+                setup(options);
+            });
+
+            it("it should have droppable instance", function() {
+                expect(options.root.droppable("instance")).toBeTruthy();
+            });
+        });
+
+
         describe("when dropping to an observable", function() {
             beforeEach(function() {
                 options = {

--- a/spec/knockout-sortable.spec.js
+++ b/spec/knockout-sortable.spec.js
@@ -1154,7 +1154,7 @@ describe("knockout-sortable", function(){
                 options = {
                     elems: $("<div data-bind='droppable: dropTo'></div>"),
                     vm: {
-                        dropTo: function(item, event, ui) {
+                        dropTo: function(item) {
                             result = item;
                         }
                      }

--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -458,7 +458,7 @@
             //set drop method
             droppableOptions.drop = function(event, ui) {
                 var droppedItem = dataGet(ui.draggable[0], DRAGKEY) || dataGet(ui.draggable[0], ITEMKEY);
-                value(droppedItem);
+                value(droppedItem, event, ui);
             };
 
             //initialize droppable


### PR DESCRIPTION
As part of some work I was doing I needed the mouse position when dropping an item. I extended the binding to pass (event and ui) additional jquery-ui parameters through.