### PR TITLE
Add dragStart and dragStop options to draggable binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ This library also includes a `draggable` binding that you can place on single it
 
 * **isEnabled** - specify whether the draggable widget should be enabled.  If this is an observable, then it will enable/disable the widget when the observable's value changes.  This option can be passed in the binding or configured globally by setting `ko.bindingHandlers.draggable.isEnabled`.
 
+* **dragstart** - specify a function to received the item being dragged when the drag starts.
+
+* **dragstop** - specify a function to received the item being dragged when the drag stops.
+
 * **options** - specify any additional options to pass on to the `.draggable` jQuery UI call.  These options can be specified in the binding or specified globally by setting `ko.bindingHandlers.draggable.options`.
 
 **Droppable binding**

--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -396,6 +396,8 @@
                 draggableOptions = ko.utils.extend({}, ko.bindingHandlers.draggable.options),
                 templateOptions = prepareTemplateOptions(valueAccessor, "data"),
                 connectClass = value.connectClass || ko.bindingHandlers.draggable.connectClass,
+                handleDragStart = value.dragStart || false,
+                handleDragStop = value.dragStop || false,
                 isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.draggable.isEnabled;
 
             value = "data" in value ? value.data : value;
@@ -421,9 +423,24 @@
                     disposeWhenNodeIsRemoved: element
                 });
             }
+            // register dragstart  event if required
+            if (typeof handleDragStart == "function") {
+                $(element).on( "dragstart", function(event, ui) {
+                    var dragItem = dataGet(ui.helper.context, DRAGKEY);
+                    handleDragStart.call(this, dragItem, event, ui);
+                });
+            }
+            // register dragstop  event if required
+            if (typeof handleDragStop == "function") {
+                $(element).on( "dragstop", function(event, ui) {
+                    var dragItem = dataGet(ui.helper.context, DRAGKEY);
+                    handleDragStop.call(this, dragItem, event, ui);
+                });
+            }
 
             //handle disposal
             ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                $(element).off(); // unregister events
                 $(element).draggable("destroy");
             });
 


### PR DESCRIPTION
This adds options for receiving the item being dragged on a callback on events "dragstart" and "dragstop"