### PR TITLE
Fixes issue where source array is corrupted with duplicates when destroyed items exist before sorting.

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -81,7 +81,7 @@
         var unwrapped = unwrap(items);
 
         if (unwrapped) {
-            for (var i = 0; i < index; i++) {
+            for (var i = 0; i <= index; i++) {
                 //add one for every destroyed item we find before the targetIndex in the target array
                 if (unwrapped[i] && unwrap(unwrapped[i]._destroy)) {
                     index++;


### PR DESCRIPTION
Steps to reproduce issue:
- Configure the sortable to use `strategyMove`
- Start with 3 items in array.
- Destroy the middle item.
- Switch the order of the remaining two items.
- Observe a duplicate item has been inserted and the destroyed item has been removed.

This is happens because currently `updateIndexFromDestroyedItems` is passed in an `index` of 1 and it only searches the source array for destroyed items up to `i < 1` however in the source array our destroyed item is at index 1, therefore the destroyed item's influence on the required indexes is ignored. 


